### PR TITLE
Fixed mismatched end macro for project_listing

### DIFF
--- a/templates/macros/page.html
+++ b/templates/macros/page.html
@@ -81,7 +81,7 @@
     </a>
     {{ self::project_info(page=page) }}
 </article>
-{% endmacro page_listing %}
+{% endmacro project_listing %}
 
 {% macro project_info(page) %}
 <div class="article-info">


### PR DESCRIPTION
I don't think this actually causes any problems, but it's inconsistent